### PR TITLE
__repr__ improvements

### DIFF
--- a/pretend.py
+++ b/pretend.py
@@ -76,6 +76,12 @@ class stub(object):
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
 
+    def __repr__(self):
+        return '<stub(%s)>' % ', '.join([
+            '%s=%r' % (key, val)
+            for key, val in self.__dict__.items()
+        ])
+
 
 def raiser(exc):
     if (

--- a/test_pretend.py
+++ b/test_pretend.py
@@ -123,6 +123,11 @@ class TestStub(object):
                 assert value == 3
                 raise ValueError
 
+    def test_default_repr(self):
+        x = stub(a=10)
+
+        assert repr(x) == "<stub(a=10)>"
+
     def test_custom_repr(self):
         x = stub(id=300, __repr__=lambda: '<Something>')
 


### PR DESCRIPTION
Users can define custom `__repr__` function.
Default stub `__repr__` looks nicer: `stub(login='l0kix2')` instead of `<pretend.stub object at 0x379cb90>`
