### PR TITLE
Note explicit support for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: python
-python: 2.7
+python: 3.5
 env:
     - TOXENV=py26
     - TOXENV=py27
     - TOXENV=py32
     - TOXENV=py33
     - TOXENV=py34
+    - TOXENV=py35
     - TOXENV=pypy
     - TOXENV=pep8
 

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,6 @@ setup(
         "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,pypy,py32,py33,py34,pep8
+envlist = py26,py27,pypy,py32,py33,py34,py35,pep8
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
The update to main python version in `.travis.yml` is needed for now: https://github.com/travis-ci/travis-ci/issues/4794#issuecomment-143758799