### PR TITLE
Refs #5 -- Make 'stub' object callable

### DIFF
--- a/pretend.py
+++ b/pretend.py
@@ -37,6 +37,7 @@ methods = set([
     "__truediv__",
     "__xor__",
 
+    "__call__",
     "__repr__",
 ])
 if PY3K:

--- a/test_pretend.py
+++ b/test_pretend.py
@@ -134,6 +134,11 @@ class TestStub(object):
         assert x.id == 300
         assert repr(x) == '<Something>'
 
+    def test_callable(self):
+        x = stub(__call__=lambda: 4)
+
+        assert x() == 4
+
 
 class TestRaiser(object):
     def test_call_raiser(self):


### PR DESCRIPTION
This PR makes the `stub` object callable by setting the `__call__` magic method.