### PR TITLE
Drop Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
     directories:
         - $HOME/.cache/pip
 env:
-    - TOXENV=py26
     - TOXENV=py27
     - TOXENV=py33
     - TOXENV=py34

--- a/pretend.py
+++ b/pretend.py
@@ -5,7 +5,7 @@ import sys
 PY3K = sys.version_info >= (3,)
 
 
-methods = set([
+methods = {
     "__iter__",
     "__len__",
     "__contains__",
@@ -39,7 +39,7 @@ methods = set([
 
     "__call__",
     "__repr__",
-])
+}
 if PY3K:
     methods.add("__next__")
     methods.add("__bool__")

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Topic :: Software Development :: Testing",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,pypy,py32,py33,py34,py35,pep8
+envlist = py27,pypy,py32,py33,py34,py35,pep8
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
Yesterday marks 3 years since the last release of Python 2.6! 🎉

To celebrate, I'm attempting to drop support for it from 156 prominent Python packages (one for every week it's past end-of-life)--including this one!

I've tried my best to remove as much 2.6-specific cruft as I can, but at the very least, this PR will remove the `'Programming Language :: Python :: 2.6'` trove classifier from this projects `setup.py`.