### PR TITLE
Add call_recorder_all()

### DIFF
--- a/pretend.py
+++ b/pretend.py
@@ -131,3 +131,11 @@ def call_recorder(func):
         return func(*args, **kwargs)
     inner.calls = []
     return inner
+
+
+def call_recorder_all(ret):
+    def inner(*args, **kwargs):
+        inner.calls.append(call(*args, **kwargs))
+        return ret
+    inner.calls = []
+    return inner

--- a/pretend.py
+++ b/pretend.py
@@ -134,8 +134,4 @@ def call_recorder(func):
 
 
 def call_recorder_all(ret):
-    def inner(*args, **kwargs):
-        inner.calls.append(call(*args, **kwargs))
-        return ret
-    inner.calls = []
-    return inner
+    return call_recorder(lambda *args, **kwargs: ret)

--- a/test_pretend.py
+++ b/test_pretend.py
@@ -2,7 +2,7 @@ import operator
 
 import pytest
 
-from pretend import stub, raiser, call, call_recorder, PY3K
+from pretend import stub, raiser, call, call_recorder, call_recorder_all, PY3K
 
 
 class TestStub(object):
@@ -181,4 +181,11 @@ class TestCallRecorder(object):
         assert f() == 3
         assert f.calls == [
             call()
+        ]
+
+    def test_simple_all(self):
+        f = call_recorder_all(3)
+        assert f(1, name='2') == 3
+        assert f.calls == [
+            call(1, name='2')   
         ]


### PR DESCRIPTION
Function would replace the common use-case of `pretend.call_recorder(lambda *args, **kwargs: ret)` with `pretend.call_recorder_all(ret)`.

I'm open to changing the name of the function. :)